### PR TITLE
Upgrade to pyarrow 12.0.0

### DIFF
--- a/docker/create_wheels.sh
+++ b/docker/create_wheels.sh
@@ -3,7 +3,7 @@
 HERE=`dirname "$0"`
 cd $HERE/..
 
-for i in 38 39 310; do
+for i in 39; do
     docker build -f docker/py${i}-wheel-manylinux2014.docker . -t casa-arrow-py${i}-wheel
     dockerid=$(docker create casa-arrow-py${i}-wheel)
     docker cp ${dockerid}:/wheels/ wheel-${i}

--- a/docker/create_wheels.sh
+++ b/docker/create_wheels.sh
@@ -3,7 +3,7 @@
 HERE=`dirname "$0"`
 cd $HERE/..
 
-for i in 39; do
+for i in 38 39 310; do
     docker build -f docker/py${i}-wheel-manylinux2014.docker . -t casa-arrow-py${i}-wheel
     dockerid=$(docker create casa-arrow-py${i}-wheel)
     docker cp ${dockerid}:/wheels/ wheel-${i}

--- a/docker/py310-wheel-manylinux2014.docker
+++ b/docker/py310-wheel-manylinux2014.docker
@@ -86,4 +86,4 @@ WORKDIR /code/casa-arrow
 RUN /opt/python/${TARGET}/bin/python -m pip install -U pip wheel setuptools auditwheel build patchelf
 RUN /opt/python/${TARGET}/bin/python -m build --wheel
 RUN mkdir -p /wheels
-RUN auditwheel repair dist/* -w /wheels --plat=manylinux2014_x86_64 --exclude libarrow_python.so --exclude libarrow.so.1100
+RUN auditwheel repair dist/* -w /wheels --plat=manylinux2014_x86_64 --exclude libarrow_python.so --exclude libarrow.so.1200

--- a/docker/py38-wheel-manylinux2014.docker
+++ b/docker/py38-wheel-manylinux2014.docker
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
 ENV CASACORE_VERSION 3.5.0
-ENV ARROW_VERSION 11.0.0
+ENV ARROW_VERSION 12.0.0
 
 # set python version
 ENV PYMAJOR 3
@@ -86,4 +86,4 @@ WORKDIR /code/casa-arrow
 RUN /opt/python/${TARGET}/bin/python -m pip install -U pip wheel setuptools auditwheel build patchelf
 RUN /opt/python/${TARGET}/bin/python -m build --wheel
 RUN mkdir -p /wheels
-RUN auditwheel repair dist/* -w /wheels --plat=manylinux2014_x86_64 --exclude libarrow_python.so --exclude libarrow.so.1100
+RUN auditwheel repair dist/* -w /wheels --plat=manylinux2014_x86_64 --exclude libarrow_python.so --exclude libarrow.so.1200

--- a/docker/py39-wheel-manylinux2014.docker
+++ b/docker/py39-wheel-manylinux2014.docker
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
 ENV CASACORE_VERSION 3.5.0
-ENV ARROW_VERSION 11.0.0
+ENV ARROW_VERSION 12.0.0
 
 # set python version
 ENV PYMAJOR 3
@@ -86,4 +86,4 @@ WORKDIR /code/casa-arrow
 RUN /opt/python/${TARGET}/bin/python -m pip install -U pip wheel setuptools auditwheel build patchelf
 RUN /opt/python/${TARGET}/bin/python -m build --wheel
 RUN mkdir -p /wheels
-RUN auditwheel repair dist/* -w /wheels --plat=manylinux2014_x86_64 --exclude libarrow_python.so --exclude libarrow.so.1100
+RUN auditwheel repair dist/* -w /wheels --plat=manylinux2014_x86_64 --exclude libarrow_python.so --exclude libarrow.so.1200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,21 @@
 name = "casa-arrow"
 version = "0.1.0"
 authors = [{ name = "Simon Perkins", email = "simon.perkins@gmail.com" }]
-dependencies = ["pyarrow == 11.0.0"]
+dependencies = ["appdirs", "pyarrow == 12.0.0"]
 description = "C++ and Python Arrow Bindings for casacore"
 readme = "README.rst"
 requires-python = ">=3.8"
 license = {text = "BSD-3-Clause"}
 
+
+[project.optional-dependencies]
+# development dependency groups
+test = [
+    "duckdb",
+    "pytest>=7.0",
+    "python-casacore>=3.5.0",
+    "requests"]
+
 [build-system]
-requires = ["setuptools", "setuptools-scm", "cython>=0.29.33,<0.30.0", "numpy>=1.24.1,<2.0.0", "pyarrow == 11.0.0"]
+requires = ["setuptools", "setuptools-scm", "cython>=0.29.33,<0.30.0", "numpy>=1.24.1,<2.0.0", "pyarrow == 12.0.0"]
 build-backend = "setuptools.build_meta"

--- a/src/column_convert_visitor.h
+++ b/src/column_convert_visitor.h
@@ -272,10 +272,8 @@ private:
             null_counts += is_defined ? 0 : 1;
         }
 
-        // If we have shapes at this point,
-        // calculate the cumulative product for each dimension
+        // Sanity check if we have shapes at this point
         if(shapes) {
-            // Sanity checks
             if(shapes->size() != nrow) {
                 return arrow::Status::Invalid("shapes.size() != nrow");
             }


### PR DESCRIPTION
With the following Arrow PR incorporated in Arrow 12.0.0, the casa-arrow test cases pass on an official pypi release, as opposed to the custom wheel referenced in the README.rst

- https://github.com/apache/arrow/pull/33802

