### PR TITLE
Configure array and complex types

### DIFF
--- a/casa_arrow/__init__.py
+++ b/casa_arrow/__init__.py
@@ -3,10 +3,10 @@ import pyarrow as pa  # noqa
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from casa_arrow._arrow_tables import Table
+    from casa_arrow_arrow_tables import Table
 
 def table(filename: str) -> "Table":
     # Defer cython module import, to avoid conflicts between casa_arrow casacore libraries
     # and python-casacore casacore libraries
-    from casa_arrow._arrow_tables import Table
+    from casa_arrow.arrow_tables import Table
     return Table(filename)

--- a/casa_arrow/config.py
+++ b/casa_arrow/config.py
@@ -1,0 +1,28 @@
+from contextlib import contextmanager
+
+_DELETE_MARKER = object()
+
+@contextmanager
+def set(**kw):
+    from casa_arrow.arrow_tables import Configuration
+    config = Configuration()
+    saved = {}
+
+    for k, v in kw.items():
+        try:
+            old = config[k]
+        except KeyError:
+            saved[k], config[k] = _DELETE_MARKER, v
+        else:
+            saved[k], config[k] = old, v
+
+    yield
+
+    for k, v in saved.items():
+        if v is _DELETE_MARKER:
+            del config[k]
+        else:
+            config[k] = v
+
+
+

--- a/casa_arrow/tests/conftest.py
+++ b/casa_arrow/tests/conftest.py
@@ -277,3 +277,43 @@ def column_case_table(tmp_path_factory):
     with mp.get_context("spawn").Pool(1) as pool:
         result = pool.apply_async(generate_column_cases_table, (str(path),))
         return result.get()
+
+
+def generate_complex_case_table(path):
+    import numpy as np
+    import pyrap.tables as pt
+
+    table_desc = [
+        {
+            "desc": {
+                "_c_order": True,
+                "comment": "COMPLEX column",
+                "dataManagerGroup": "",
+                "dataManagerType": "",
+                "keywords": {},
+                "ndim": 2,
+                "maxlen": 0,
+                "shape": [2, 4],
+                "option": 0,
+                "valueType": "dcomplex",
+            },
+            "name": "COMPLEX",
+        }]
+
+    table_desc = pt.maketabdesc(table_desc)
+    table_name = os.path.join(path, "test.table")
+    nrow = 3
+
+    with pt.table(table_name, table_desc, nrow=nrow, ack=False) as T:
+        for i in range(nrow):
+            T.putcell("COMPLEX", i, np.full((2, 4), i))
+
+    return table_name
+
+@pytest.fixture
+def complex_case_table(tmp_path_factory):
+    path = tmp_path_factory.mktemp("complex_cases")
+
+    with mp.get_context("spawn").Pool(1) as pool:
+        result = pool.apply_async(generate_complex_case_table, (str(path),))
+        return result.get()

--- a/casa_arrow/tests/test_pytable.py
+++ b/casa_arrow/tests/test_pytable.py
@@ -68,6 +68,28 @@ def test_column_cases(column_case_table, capfd):
     assert "Ignoring UNCONSTRAINED" in captured.err
 
 
+def test_complex_cases(complex_case_table):
+    from casa_arrow.arrow_tables import ComplexDoubleType
+    from casa_arrow import config
+
+    table = ca.table(complex_case_table)
+
+    with config.set(**{"casa.convert.strategy": "fixed complex"}):
+        T = table.to_arrow()
+        assert T.column("COMPLEX").type == pa.list_(pa.list_(ComplexDoubleType(), 4), 2)
+
+    with config.set(**{"casa.convert.strategy": "fixed"}):
+        T = table.to_arrow()
+        assert T.column("COMPLEX").type == pa.list_(pa.list_(pa.list_(pa.float64(), 2), 4), 2)
+
+    with config.set(**{"casa.convert.strategy": "list complex"}):
+        T = table.to_arrow()
+        assert T.column("COMPLEX").type == pa.list_(pa.list_(ComplexDoubleType()))
+
+    with config.set(**{"casa.convert.strategy": "list"}):
+        T = table.to_arrow()
+        assert T.column("COMPLEX").type == pa.list_(pa.list_(pa.list_(pa.float64())))
+
 def test_partial_read(sorting_table):
     """ Tests that partial reads work """
     T = ca.table(sorting_table)
@@ -174,7 +196,7 @@ def test_duckdb(partitioned_dataset):
 
 
 def test_config():
-    from casa_arrow._arrow_tables import Configuration
+    from casa_arrow.arrow_tables import Configuration
     config = Configuration()
     config["blah"] = "foo"
     assert config["blah"] == "foo"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def create_extensions():
         print(f"library_dirs={library_dirs}", file=f)
         print(f"libraries={libraries}", file=f)
 
-    ext_modules = [Extension("casa_arrow._arrow_tables", ["casa_arrow/*.pyx"])]
+    ext_modules = [Extension("casa_arrow.arrow_tables", ["casa_arrow/*.pyx"])]
     ext_modules = cythonize(ext_modules)
 
     for ext in ext_modules:

--- a/src/column_convert_visitor.cpp
+++ b/src/column_convert_visitor.cpp
@@ -17,6 +17,47 @@ ColumnConvertVisitor::ColumnConvertVisitor(
     assert(endrow <= column.nrow());
 }
 
+Result<std::shared_ptr<arrow::Array>>
+ColumnConvertVisitor::MakeArrowPrimitiveArray(
+        const std::shared_ptr<Buffer> & buffer,
+        casacore::uInt nelements,
+        const std::shared_ptr<DataType> & arrow_dtype) {
+
+    if(auto complex_dtype = std::dynamic_pointer_cast<ComplexType>(arrow_dtype)) {
+        auto child_array = std::make_shared<arrow::PrimitiveArray>(
+            complex_dtype->value_type(), 2*nelements, buffer);
+
+        auto & config = ServiceLocator::configuration();
+        auto convert_strategy = config.GetDefault("casa.convert.strategy", "fixed");
+        auto npos = std::string::npos;
+
+        if(auto pos = convert_strategy.find("complex"); pos != npos) {
+            // NOTE(sjperkins)
+            // Check the FixedSizeListAray layout documents
+            // https://arrow.apache.org/docs/format/Columnar.html#fixed-size-list-layout
+            // A single empty buffer {nullptr} must be provided otherwise this segfaults
+            auto array_data = arrow::ArrayData::Make(
+                complex_dtype, nelements, {nullptr}, {child_array->data()});
+            return complex_dtype->MakeArray(std::move(array_data));
+        } else if(auto pos = convert_strategy.find("fixed"); pos == 0) {
+            return arrow::FixedSizeListArray::FromArrays(child_array, 2);
+        } else if(auto pos = convert_strategy.find("list"); pos == 0) {
+            arrow::Int32Builder builder(pool);
+            ARROW_RETURN_NOT_OK(builder.Reserve(nelements + 1));
+            for(auto i=0; i < nelements + 1; ++i)
+                { ARROW_RETURN_NOT_OK(builder.Append(2*i)); }
+            ARROW_ASSIGN_OR_RAISE(auto offsets, builder.Finish());
+            return arrow::ListArray::FromArrays(*offsets, *child_array);
+        } else {
+            return arrow::Status::Invalid("Invalid 'casa.convert.strategy=", convert_strategy, "'");
+        }
+    } else {
+        return std::make_shared<arrow::PrimitiveArray>(arrow_dtype, nelements, buffer);
+    }
+}
+
+
+
 arrow::Status ColumnConvertVisitor::VisitTpBool() {
     // TODO(sjperkins)
     // Looks like casacore bool is actually a char, improve this

--- a/src/column_convert_visitor.cpp
+++ b/src/column_convert_visitor.cpp
@@ -44,7 +44,7 @@ ColumnConvertVisitor::MakeArrowPrimitiveArray(
         } else if(auto pos = convert_strategy.find("list"); pos == 0) {
             arrow::Int32Builder builder(pool);
             ARROW_RETURN_NOT_OK(builder.Reserve(nelements + 1));
-            for(auto i=0; i < nelements + 1; ++i)
+            for(decltype(nelements) i=0; i < nelements + 1; ++i)
                 { ARROW_RETURN_NOT_OK(builder.Append(2*i)); }
             ARROW_ASSIGN_OR_RAISE(auto offsets, builder.Finish());
             return arrow::ListArray::FromArrays(*offsets, *child_array);

--- a/src/column_convert_visitor.h
+++ b/src/column_convert_visitor.h
@@ -149,9 +149,6 @@ private:
             int64_t null_counts) {
 
         auto column = casacore::ArrayColumn<T>(this->column);
-        auto nelements = std::accumulate(
-                shapes.begin(), shapes.end(), casacore::uInt(0),
-                [](auto i, const auto & s) { return i + s.product(); });
 
         if constexpr(std::is_same<T, casacore::String>::value) {
             // Handle string cases with Arrow StringBuilders
@@ -166,6 +163,9 @@ private:
             }
             ARROW_ASSIGN_OR_RAISE(this->array, builder.Finish());
         } else {
+            auto nelements = std::accumulate(
+                    shapes.begin(), shapes.end(), casacore::uInt(0),
+                    [](auto i, const auto & s) { return i + s.product(); });
             ARROW_ASSIGN_OR_RAISE(auto allocation, arrow::AllocateBuffer(nelements*sizeof(T), pool));
             auto buffer = std::shared_ptr<Buffer>(std::move(allocation));
             auto * buf_ptr = reinterpret_cast<T *>(buffer->mutable_data());

--- a/src/column_convert_visitor.h
+++ b/src/column_convert_visitor.h
@@ -9,9 +9,11 @@
 
 #include "casa_visitors.h"
 #include "complex_type.h"
+#include "service_locator.h"
 
 using ::arrow::Buffer;
 using ::arrow::DataType;
+using ::arrow::Result;
 using ::arrow::Status;
 
 using ::casacore::IPosition;
@@ -53,29 +55,10 @@ private:
         return Status::Invalid(arrow_dtype->ToString(), " incompatible with casacore::String");
     }
 
-    std::shared_ptr<arrow::Array> MakeArrowPrimitiveArray(
+    Result<std::shared_ptr<arrow::Array>> MakeArrowPrimitiveArray(
             const std::shared_ptr<Buffer> & buffer,
             casacore::uInt nelements,
-            const std::shared_ptr<DataType> & arrow_dtype) {
-
-        if(auto complex_dtype = std::dynamic_pointer_cast<ComplexType>(arrow_dtype)) {
-            auto child_array = arrow::PrimitiveArray(complex_dtype->value_type(),
-                                                     2*nelements, buffer, nullptr, 0, 0);
-            // NOTE(sjperkins)
-            // Check the FixedSizeListAray layout documents
-            // https://arrow.apache.org/docs/format/Columnar.html#fixed-size-list-layout
-            // A single empty buffer {nullptr} must be provided otherwise this segfaults
-            auto array_data = arrow::ArrayData::Make(
-                complex_dtype, nelements, {nullptr}, {child_array.data()},
-                0, 0);
-
-            return complex_dtype->MakeArray(std::move(array_data));
-
-        } else {
-            return std::make_shared<arrow::PrimitiveArray>(
-                arrow_dtype, nelements, buffer, nullptr, 0, 0);
-        }
-    }
+            const std::shared_ptr<DataType> & arrow_dtype);
 
     template <typename T>
     Status ConvertScalarColumn(const std::shared_ptr<DataType> & arrow_dtype) {
@@ -108,7 +91,7 @@ private:
                 return Status::Invalid("ConvertScalarColumn ", column_desc.name(), " ", e.what());
             }
 
-            this->array = MakeArrowPrimitiveArray(buffer, nrow, arrow_dtype);
+            ARROW_ASSIGN_OR_RAISE(this->array, MakeArrowPrimitiveArray(buffer, nrow, arrow_dtype));
         }
 
         return this->array->ValidateFull();
@@ -147,7 +130,7 @@ private:
                 return Status::Invalid("MakeFixedArrayBuffer ", column_desc.name(), " ", e.what());
             }
 
-            this->array = MakeArrowPrimitiveArray(buffer, nelements, arrow_dtype);
+            ARROW_ASSIGN_OR_RAISE(this->array, MakeArrowPrimitiveArray(buffer, nelements, arrow_dtype));
         }
 
         // Fortran ordering
@@ -211,7 +194,7 @@ private:
                                        column_desc.name());
             }
 
-            this->array = MakeArrowPrimitiveArray(buffer, nelements, arrow_dtype);
+            ARROW_ASSIGN_OR_RAISE(this->array, MakeArrowPrimitiveArray(buffer, nelements, arrow_dtype));
         }
 
         // NOTE(sjperkins)
@@ -243,17 +226,17 @@ private:
         //    offsets = [0] + cumsum((1*[10] + 1*[10]))
 
 
-        auto ndim = column_desc.ndim();
 
         // Compute the products
-        auto products = std::vector<IPosition>(nrow, IPosition(column_desc.ndim(), 1));
+        auto ndim = column_desc.ndim();
+        auto products = std::vector<IPosition>(nrow, IPosition(ndim, 1));
 
         for(casacore::uInt row=startrow; row < endrow; ++row) {
             auto lrow = local_row(row);
             const auto & shape = shapes[lrow];
             auto & product = products[lrow];
 
-            for(ssize_t d=ndim - 2; d >= 0; --d) {
+            for(int d=ndim - 2; d >= 0; --d) {
                 product[d] *= product[d + 1] * shape[d + 1];
             }
         }
@@ -263,33 +246,25 @@ private:
             unsigned int noffsets = std::accumulate(products.begin(), products.end(), 1,
                 [d](auto i, const auto & p) { return i + p[d]; });
 
-            ARROW_ASSIGN_OR_RAISE(
-                auto offset_buffer,
-                arrow::AllocateBuffer(noffsets*sizeof(noffsets), pool));
-
-            int32_t * optr = reinterpret_cast<int32_t *>(offset_buffer->mutable_data());
+            arrow::Int32Builder builder(pool);
             unsigned int running_offset = 0;
-            unsigned int o = 0;
-            optr[o++] = running_offset;
+            unsigned int o = 1;
+            ARROW_RETURN_NOT_OK(builder.Reserve(noffsets));
+            ARROW_RETURN_NOT_OK(builder.Append(running_offset));
 
             for(casacore::uInt row=startrow; row < endrow; ++row) {
                 auto repeats = products[local_row(row)][d];
                 auto dim_size = shapes[local_row(row)][d];
 
-                for(auto r=0; r < repeats; ++r) {
+                for(auto r=0; r < repeats; ++r, ++o) {
                     running_offset += dim_size;
-                    optr[o++] = running_offset;
+                    ARROW_RETURN_NOT_OK(builder.Append(running_offset));
                 }
             }
 
-            if(o != noffsets) {
-                return Status::Invalid("o != noffsets "
-                                       "during conversion of variably shaped column ",
-                                       column_desc.name());
-            }
+            if(o != noffsets) { return arrow::Status::Invalid("o != noffsets"); }
 
-            auto offsets = std::make_shared<arrow::PrimitiveArray>(
-                arrow::int32(), noffsets, std::move(offset_buffer));
+            ARROW_ASSIGN_OR_RAISE(auto offsets, builder.Finish());
             ARROW_ASSIGN_OR_RAISE(this->array, arrow::ListArray::FromArrays(*offsets, *this->array));
             // NOTE(sjperkins): Perhaps remove this for performance
             ARROW_RETURN_NOT_OK(this->array->ValidateFull());
@@ -351,7 +326,11 @@ private:
 
         assert(column_desc.ndim() >= 1);
 
-        if(column_desc.isFixedShape()) {
+        auto & config = ServiceLocator::configuration();
+        auto convert_method = config.GetDefault("casa.convert.strategy", "fixed");
+        auto list_convert = convert_method.find("list") == 0;
+
+        if(!list_convert && column_desc.isFixedShape()) {
             return ConvertFixedArrayColumn<T>(arrow_dtype, column_desc.shape());
         }
 
@@ -375,13 +354,12 @@ private:
 
         // No nulls and all shapes are equal, we can represent this with a
         // fixed shape list
-        if(null_counts == 0 && shapes_equal) {
+        if(!list_convert && null_counts == 0 && shapes_equal) {
             return ConvertFixedArrayColumn<T>(arrow_dtype, shapes[0]);
         }
 
         return ConvertVariableArrayColumn<T>(arrow_dtype, shapes, nulls, null_counts);
     }
 };
-
 
 #endif


### PR DESCRIPTION
Support configuration of array and complex types. Current options are:

1. `fixed`: Array columns will be represented as nested Fixed Size Lists, if possible. Complex data will be represented as Fixed Size Lists of length 2.
2. `list`: Both Arrays and Complex data will be represented as nested lists.
3. `fixed complex`: Arrays will be represented as nested Fixed Size Lists, if possible. Complex data will be represented via extension types.
4. `list complex`: Arrays will be represented as nested list, if possible. Complex data will be represented via extension types.

(2) is the most general case and will allow MS data to be plugged into downstream computation engines.