### PR TITLE
Run cron job twice a week to keep the build caches fresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     - master
   pull_request:
   schedule:
-    - cron: '30 2 * * 1' # Every Monday @ 2h30am UTC
+    - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
 
 env:
   VCPKG_DEFAULT_BINARY_CACHE: /tmp/vcpkg-archives


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy

> GitHub will remove any cache entries that have not been accessed in over 7 days.

Run twice a week just to be sure to keep the cache entries fresh.